### PR TITLE
Error WC_Gateway_Wirecard class not found

### DIFF
--- a/admin/class-pay4pay-admin.php
+++ b/admin/class-pay4pay-admin.php
@@ -20,7 +20,7 @@ class Pay4Pay_Admin {
 
 	private function __construct() {
 		// handle options
-		add_action( 'woocommerce_init' , array( &$this , 'add_payment_options') );
+		add_action( 'woocommerce_init' , array( &$this , 'add_payment_options'), 99 );
 		add_action( 'woocommerce_update_options_checkout' , array( &$this , 'add_payment_options') );
 		
 		// payment gateways table


### PR DESCRIPTION
Hello! I'm try to use your plugin with more than 5 payments gateways. In the moment I activate the plugin hive me an error because can't find the "WC_Gateway_Wirecard" class. I think this happened because the "add_payment_options" running before load all the gateways. So I add the priority 99 to be sure this will run after all the gateways are loaded. After this change, all works perfect.

Great plugin :)
