### PR TITLE
Fix for warning message

### DIFF
--- a/woocommerce-payforpayment.php
+++ b/woocommerce-payforpayment.php
@@ -111,7 +111,13 @@ jQuery(document).ready(function($){
 
 			if ( $settings['pay4pay_charges_fixed'] || $settings['pay4pay_charges_percentage'] ) {
 				$cart = WC()->cart;
-				if ( ! $disable_on_free_shipping || ! in_array( 'free_shipping' , WC()->session->get( 'chosen_shipping_methods' )) ) {
+				$chosen_methods=  WC()->session->get( 'chosen_shipping_methods' );
+				if (is_null($chosen_methods))
+				{
+				$chosen_methods=[];
+				}
+				
+				if ( ! $disable_on_free_shipping || ! in_array( 'free_shipping' , $chosen_methods) ) {
 					$cost = floatval($settings['pay4pay_charges_fixed']);
 				
 					//  √ $this->cart_contents_total + √ $this->tax_total + √ $this->shipping_tax_total + $this->shipping_total + $this->fee_total,


### PR DESCRIPTION
Fix for warning message 
Warning: in_array() expects parameter 2 to be array, null given in/wp-content/plugins/woocommerce-pay-for-payment/woocommerce-payforpayment.php on line 114
Reported in support forum https://wordpress.org/support/topic/error-on-top-of-the-basket-page?replies=5#post-7042735